### PR TITLE
Fixed bug where image loop would not start properly if a tumblr URL request fails. 

### DIFF
--- a/src/api/fetchTumblrPics.js
+++ b/src/api/fetchTumblrPics.js
@@ -26,7 +26,8 @@ const fetchPics = (id, imageType, offset = 0, limit) => {
 
           return url;
         });
-    });
+	})
+	.catch((error) => console.log(error));
 };
 
 /**


### PR DESCRIPTION
Fixed an issue I was having in reusing old blogs that either died or simply didn't work for whatever reason.

I'm working on proper notification for the user, but currently they are fired twice initially and will be re-fired whenever more images are needed, so I've not included it yet. Thought it would be better to at least prevent the whole thing falling over first and provide proper notification later. 