### PR TITLE
Added the ability to edit the config page of a generated link.

### DIFF
--- a/src/Containers/Pages/ConfigPage.js
+++ b/src/Containers/Pages/ConfigPage.js
@@ -903,6 +903,18 @@ class ConfigPage extends React.Component {
                   Generate Link
                 </Button>
               </Tooltip>
+              <FormControlLabel
+                 control={
+                   <Switch
+                      checked={store.config.allowConfigEdit}
+                      onChange={this.handleCheckChange(
+                        "allowConfigEdit"
+                      )}
+                      value="allowConfigEdit"
+                   />
+                  }
+                 label="Editable?"
+                />
             </div>
           </Paper>
         </div>

--- a/src/Containers/Pages/GamePage.js
+++ b/src/Containers/Pages/GamePage.js
@@ -35,6 +35,9 @@ const styles = theme => ({
     background: `url(${BackgroundImage})`,
     backgroundSize: "cover",
     backgroundAttachment: "fixed"
+  },
+  buttonMargin: {
+    margin: "5px"
   }
 });
 
@@ -89,7 +92,28 @@ class GamePage extends React.Component {
   componentWillUnmount() {
     stopGame();
   }
+  
+  backToConfig() {
+    this.props.history.push('/');
+  }
 
+  renderBackToConfig() {
+    if(store.config.allowConfigEdit) {
+      return (
+        <Button
+          onClick={ () => {
+            this.backToConfig();
+          }}
+          variant="raised"
+          color="secondary"
+          className={this.props.classes.buttonMargin}
+        >
+        Configure game
+        </Button>
+      );
+    }
+  }
+  
   render() {
     if (!this.state.gameStarted) {
       return (
@@ -101,9 +125,13 @@ class GamePage extends React.Component {
             }}
             variant="raised"
             color="secondary"
+            className={this.props.classes.buttonMargin}
           >
             start game
-          </Button>
+          </Button>  
+          {
+            this.renderBackToConfig()
+          }
         </div>
       );
     }

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -65,7 +65,8 @@ const defaultConfig = {
     precum: true,
     buttplug: true,
     pickYourPoison: true
-  }
+  },
+  allowConfigEdit: true
 };
 
 export default () => {


### PR DESCRIPTION
Raised in issue #30, allows a user to go back and edit a previous link, if the link was generated and allowed to be edited.

Editable defaults to true, so now a user must specify if they _don't_ want their shared link to be editable.